### PR TITLE
Tcpdirect 5.15 1

### DIFF
--- a/drivers/net/ethernet/mellanox/mlx4/en_rx.c
+++ b/drivers/net/ethernet/mellanox/mlx4/en_rx.c
@@ -42,6 +42,7 @@
 #include <linux/if_vlan.h>
 #include <linux/vmalloc.h>
 #include <linux/irq.h>
+#include <linux/pci-p2pdma.h>
 
 #include <net/ip.h>
 #if IS_ENABLED(CONFIG_IPV6)
@@ -495,6 +496,8 @@ static int mlx4_en_complete_rx_desc(struct mlx4_en_priv *priv,
 
 		__skb_fill_page_desc(skb, nr, page, frags->page_offset,
 				     frag_size);
+		if (is_pci_p2pdma_page(page))
+			skb_devmem_frag_set(skb);
 
 		truesize += frag_info->frag_stride;
 		if (frag_info->frag_stride == PAGE_SIZE / 2) {

--- a/drivers/net/ethernet/mellanox/mlx4/en_rx.c
+++ b/drivers/net/ethernet/mellanox/mlx4/en_rx.c
@@ -65,11 +65,20 @@ static int mlx4_alloc_page(struct mlx4_en_priv *priv,
 	if (unlikely(!page))
 		return -ENOMEM;
 
-/* TODO: replace dma with p2pdma */
-	dma = dma_map_page(priv->ddev, page, 0, PAGE_SIZE, priv->dma_dir);
-	if (unlikely(dma_mapping_error(priv->ddev, dma))) {
-		__free_page(page);
-		return -ENOMEM;
+	if (is_pci_p2pdma_page(page)) {
+		struct scatterlist sgl;
+		sgl.page_link = (unsigned long)page;
+		sgl.offset = 0;
+		sgl.length = PAGE_SIZE;
+		pci_p2pdma_compute_maptype_if_not_cached(page->pgmap, priv->ddev);
+		pci_p2pdma_map_sg(priv->ddev, &sgl, 1, priv->dma_dir);
+		dma = sgl.dma_address;
+	} else {
+		dma = dma_map_page(priv->ddev, page, 0, PAGE_SIZE, priv->dma_dir);
+		if (unlikely(dma_mapping_error(priv->ddev, dma))) {
+			__free_page(page);
+			return -ENOMEM;
+		}
 	}
 	frag->page = page;
 	frag->dma = dma;
@@ -101,8 +110,16 @@ static void mlx4_en_free_frag(const struct mlx4_en_priv *priv,
 			      struct mlx4_en_rx_alloc *frag)
 {
 	if (frag->page) {
-		dma_unmap_page(priv->ddev, frag->dma,
-			       PAGE_SIZE, priv->dma_dir);
+		if (is_pci_p2pdma_page(frag->page)) {
+			struct scatterlist sgl;
+			sgl.page_link = (unsigned long)page;
+			sgl.offset = 0;
+			sgl.length = PAGE_SIZE;
+			sgl.dma_address = frag->dma;
+			pci_p2pdma_unmap_sg(priv->ddev, &sgl, 1, priv->dma_dir);
+		} else
+			dma_unmap_page(priv->ddev, frag->dma,
+				       PAGE_SIZE, priv->dma_dir);
 		netdev_rxq_free_page(frag->page);
 	}
 	/* We need to clear all fields, otherwise a change of priv->log_rx_info
@@ -459,8 +476,16 @@ void mlx4_en_deactivate_rx_ring(struct mlx4_en_priv *priv,
 	int i;
 
 	for (i = 0; i < ring->page_cache.index; i++) {
-		dma_unmap_page(priv->ddev, ring->page_cache.buf[i].dma,
-			       PAGE_SIZE, priv->dma_dir);
+		if (is_pci_p2pdma_page(ring->page_cache.buf[i].page)) {
+			struct scatterlist sgl;
+			sgl.page_link = (unsigned long)ring->page_cache.buf[i].page;
+			sgl.offset = 0;
+			sgl.length = PAGE_SIZE;
+			sgl.dma_address = ring->page_cache.buf[i].dma;
+			pci_p2pdma_unmap_sg(priv->ddev, &sgl, 1, priv->dma_dir);
+		} else
+			dma_unmap_page(priv->ddev, ring->page_cache.buf[i].dma,
+				       PAGE_SIZE, priv->dma_dir);
 		put_page(ring->page_cache.buf[i].page);
 	}
 	ring->page_cache.index = 0;
@@ -516,7 +541,15 @@ static int mlx4_en_complete_rx_desc(struct mlx4_en_priv *priv,
 			release = frags->page_offset + frag_info->frag_size > PAGE_SIZE;
 		}
 		if (release) {
-			dma_unmap_page(priv->ddev, dma, PAGE_SIZE, priv->dma_dir);
+			if (is_pci_p2pdma_page(frag->page)) {
+				struct scatterlist sgl;
+				sgl.page_link = (unsigned long)frag->page;
+				sgl.offset = 0;
+				sgl.length = PAGE_SIZE;
+				sgl.dma_address = dma;
+				pci_p2pdma_unmap_sg(priv->ddev, &sgl, 1, priv->dma_dir);
+			} else
+				dma_unmap_page(priv->ddev, dma, PAGE_SIZE, priv->dma_dir);
 			frags->page = NULL;
 		} else {
 			page_ref_inc(page);

--- a/drivers/pci/p2pdma.c
+++ b/drivers/pci/p2pdma.c
@@ -35,12 +35,6 @@ struct pci_p2pdma {
 	struct xarray map_types;
 };
 
-struct pci_p2pdma_pagemap {
-	struct dev_pagemap pgmap;
-	struct pci_dev *provider;
-	u64 bus_offset;
-};
-
 static struct pci_p2pdma_pagemap *to_p2p_pgmap(struct dev_pagemap *pgmap)
 {
 	return container_of(pgmap, struct pci_p2pdma_pagemap, pgmap);
@@ -1057,3 +1051,24 @@ int pci_free_p2pmem_iov(const struct iovec *iov)
 
 	return 0;
 }
+
+void pci_p2pdma_compute_maptype_if_not_cached(struct dev_pagemap *pgmap,
+					      struct pci_dev *client)
+{
+	enum pci_p2pdma_map_type type = PCI_P2PDMA_MAP_UNKNOWN;
+	struct pci_dev *p2p_dev = to_p2p_pgmap(pgmap)->provider;
+	struct pci_p2pdma *p2pdma;
+	int dist;
+	rcu_read_lock();
+	p2pdma = rcu_dereference(p2p_dev->p2pdma);
+	if (p2pdma)
+		type = xa_to_value(xa_load(&p2pdma->map_types,
+					   map_types_idx(client)));
+	rcu_read_unlock();
+
+	if (type == PCI_P2PDMA_MAP_UNKNOWN) {
+		type = calc_map_type_and_dist(p2p_dev, client, &dist, true);
+		printk(KERN_ERR "p2pdma map type: %d\n", (int)type);
+	}
+}
+EXPORT_SYMBOL_GPL(pci_p2pdma_compute_maptype_if_not_cached);

--- a/drivers/pci/p2pdma.c
+++ b/drivers/pci/p2pdma.c
@@ -741,6 +741,18 @@ void pci_free_p2pmem(struct pci_dev *pdev, void *addr, size_t size)
 }
 EXPORT_SYMBOL_GPL(pci_free_p2pmem);
 
+void pci_free_p2pmem_page(struct page* pg)
+{
+	struct pci_dev *pdev;
+
+	if (!pg->pgmap)
+		printk(KERN_ERR "ERR: unexpected missing ptr\n");
+
+	pdev = to_p2p_pgmap(pg->pgmap)->provider;
+	pci_free_p2pmem(pdev, page_to_virt(pg), PAGE_SIZE);
+}
+
+
 /**
  * pci_p2pmem_virt_to_bus - return the PCI bus address for a given virtual
  *	address obtained with pci_alloc_p2pmem()
@@ -1041,9 +1053,7 @@ int pci_free_p2pmem_iov(const struct iovec *iov)
 		return -EINVAL;
 	}
 
-	pdev = to_p2p_pgmap(pg->pgmap)->provider;
-
-	pci_free_p2pmem(pdev, page_to_virt(pg), PAGE_SIZE);
+	put_page(pg);
 
 	return 0;
 }

--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -740,11 +740,18 @@ struct netdev_rx_queue {
 	struct xsk_buff_pool            *pool;
 #endif
 	struct pci_dev __rcu		*p2pdma_dev;
+	struct file __rcu		*dmabuf_frags;
 } ____cacheline_aligned_in_smp;
 
 struct page * __netdev_rxq_alloc_page(struct netdev_rx_queue *rxq,
 				      int nid, gfp_t gfp_mask,
 				      unsigned int order);
+
+struct page * __netdev_rxq_alloc_page_from_dmabuf_pool(
+		struct netdev_rx_queue *rxq,
+		int nid, gfp_t gfp_mask,
+		unsigned int order);
+
 
 static inline struct page * netdev_rxq_alloc_page(struct netdev_rx_queue *rxq,
 						  int nid, gfp_t gfp_mask,
@@ -753,13 +760,15 @@ static inline struct page * netdev_rxq_alloc_page(struct netdev_rx_queue *rxq,
 	/* TODO: static_branch this unlikely p2pdma path */
 	if (unlikely(rcu_access_pointer(rxq->p2pdma_dev)))
 		return __netdev_rxq_alloc_page(rxq, nid, gfp_mask, order);
+	else if (unlikely(rcu_access_pointer(rxq->dmabuf_frags)))
+		return __netdev_rxq_alloc_page_from_dmabuf_pool(rxq, nid, gfp_mask, order);
 
 	return __alloc_pages_node(nid, gfp_mask, order);
 }
 
 static inline void netdev_rxq_free_page(struct page *pg)
 {
-	if (is_pci_p2pdma_page(pg)) {
+	if (is_pci_p2pdma_page(pg) || is_dma_buf_frags_dummy_page(pg)) {
 		/* pci_free_p2pmem */
 		net_info_ratelimited("p2pdma free (skipped)");
 		put_page(pg);

--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -762,6 +762,7 @@ static inline void netdev_rxq_free_page(struct page *pg)
 	if (is_pci_p2pdma_page(pg)) {
 		/* pci_free_p2pmem */
 		net_info_ratelimited("p2pdma free (skipped)");
+		put_page(pg);
 		return;
 	}
 

--- a/include/linux/pci-p2pdma.h
+++ b/include/linux/pci-p2pdma.h
@@ -12,6 +12,24 @@
 #define _LINUX_PCI_P2PDMA_H
 
 #include <linux/pci.h>
+#include <linux/uio.h>
+
+struct pci_p2pdma_pagemap {
+	struct dev_pagemap pgmap;
+	struct pci_dev *provider;
+	u64 bus_offset;
+};
+
+
+struct p2pdma_pages_vec {
+	struct iov_iter pages_iter;
+	struct bio_vec *bv;
+	size_t num_pages;
+	size_t size;
+
+	struct pci_p2pdma_pagemap p2p_pgmap;
+	void *private_ptr;
+};
 
 struct block_device;
 struct scatterlist;
@@ -43,6 +61,8 @@ int pci_p2pdma_enable_store(const char *page, struct pci_dev **p2p_dev,
 			    bool *use_p2pdma);
 ssize_t pci_p2pdma_enable_show(char *page, struct pci_dev *p2p_dev,
 			       bool use_p2pdma);
+void pci_p2pdma_compute_maptype_if_not_cached(struct dev_pagemap *pgmap,
+					      struct pci_dev *client);
 #else /* CONFIG_PCI_P2PDMA */
 static inline int pci_p2pdma_add_resource(struct pci_dev *pdev, int bar,
 		size_t size, u64 offset)
@@ -112,6 +132,10 @@ static inline ssize_t pci_p2pdma_enable_show(char *page,
 		struct pci_dev *p2p_dev, bool use_p2pdma)
 {
 	return sprintf(page, "none\n");
+}
+void pci_p2pdma_compute_maptype_if_not_cached(struct dev_pagemap *pgmap,
+					      struct pci_dev *client)
+{
 }
 #endif /* CONFIG_PCI_P2PDMA */
 

--- a/include/linux/pci-p2pdma.h
+++ b/include/linux/pci-p2pdma.h
@@ -29,6 +29,7 @@ bool pci_has_p2pmem(struct pci_dev *pdev);
 struct pci_dev *pci_p2pmem_find_many(struct device **clients, int num_clients);
 void *pci_alloc_p2pmem(struct pci_dev *pdev, size_t size);
 void pci_free_p2pmem(struct pci_dev *pdev, void *addr, size_t size);
+void pci_free_p2pmem_page(struct page* pg);
 pci_bus_addr_t pci_p2pmem_virt_to_bus(struct pci_dev *pdev, void *addr);
 struct scatterlist *pci_p2pmem_alloc_sgl(struct pci_dev *pdev,
 					 unsigned int *nents, u32 length);
@@ -68,6 +69,9 @@ static inline void *pci_alloc_p2pmem(struct pci_dev *pdev, size_t size)
 }
 static inline void pci_free_p2pmem(struct pci_dev *pdev, void *addr,
 		size_t size)
+{
+}
+static inline void pci_free_p2pmem_page(struct page* pg)
 {
 }
 static inline pci_bus_addr_t pci_p2pmem_virt_to_bus(struct pci_dev *pdev,

--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -29,6 +29,7 @@
 #include <linux/rcupdate.h>
 #include <linux/hrtimer.h>
 #include <linux/dma-mapping.h>
+#include <linux/dma-buf.h>
 #include <linux/netdev_features.h>
 #include <linux/pci-p2pdma.h>
 #include <linux/sched.h>
@@ -3234,6 +3235,10 @@ static inline dma_addr_t skb_frag_dma_map(struct device *dev,
 		pci_p2pdma_compute_maptype_if_not_cached(skb_frag_page(frag)->pgmap, to_pci_dev(dev));
 		pci_p2pdma_map_sg(dev, &sgl, 1, dir);
 		return sgl.dma_address;
+	} else if (unlikely(is_dma_buf_frags_dummy_page(skb_frag_page(frag)))) {
+		struct page *page = skb_frag_page(frag);
+		dma_addr_t dma_addr = (dma_addr_t)page->zone_device_data;
+		return dma_addr + skb_frag_off(frag) + offset;
 	} else {
 		return dma_map_page(dev, skb_frag_page(frag),
 				    skb_frag_off(frag) + offset, size, dir);

--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -3100,31 +3100,6 @@ static inline void __skb_frag_unref(skb_frag_t *frag, bool recycle)
 {
 	struct page *page = skb_frag_page(frag);
 
-	/* Do not call put_page on a page from a p2pdma genpool.
-	 *
-	 * This currently is a huge mem leak:
-	 *
-	 * It relies on setsockopt SO_DEVMEM_OFFSET to later release
-	 * the page to the genpool using pci_free_p2pmem_iov.
-	 *
-	 * But that
-	 * 1. only happens for payload pages passed to userspace with
-	 *    cmsg. Not, for instance, for a page backing initial SYN.
-	 *    Those are currently leaked.
-	 * 2. even for payload pages trusts a user process that may
-	 *    exit/crash at any time, or pass a wrong address, or pass
-	 *    the same address multiple times.
-	 * 3. does not refcount readers, assumes exactly one.
-	 *
-	 * Clearly this is ONLY ok for initial best-case benchmarking.
-	 *
-	 * First improvement is to release back to genpool unless a
-	 * previous put_cmsg in tcp_recvmsg expressly marked the page
-	 * as passed to user. That addresses SYN and similar cases.
-	 */
-	if (is_pci_p2pdma_page(page))
-		return;
-
 #ifdef CONFIG_PAGE_POOL
 	if (recycle && page_pool_return_skb_page(page))
 		return;

--- a/include/linux/socket.h
+++ b/include/linux/socket.h
@@ -314,6 +314,8 @@ struct ucred {
 					  * plain text and require encryption
 					  */
 
+#define MSG_P2PDMAASIS 0x2000000 /* don't copy p2pdma pages but return them as cmsg instead */
+
 #define MSG_ZEROCOPY	0x4000000	/* Use user data in kernel path */
 #define MSG_FASTOPEN	0x20000000	/* Send data in TCP SYN */
 #define MSG_CMSG_CLOEXEC 0x40000000	/* Set close_on_exec for file

--- a/include/linux/socket.h
+++ b/include/linux/socket.h
@@ -314,7 +314,9 @@ struct ucred {
 					  * plain text and require encryption
 					  */
 
-#define MSG_P2PDMAASIS 0x2000000 /* don't copy p2pdma pages but return them as cmsg instead */
+#define MSG_P2PDMAASIS 0x2000000 /* Recv: don't copy p2pdma pages but return them as cmsg instead
+				  * Send: use fd in msghdr to send p2pdma pages, also requires MSG_ZEROCOPY
+				  */
 
 #define MSG_ZEROCOPY	0x4000000	/* Use user data in kernel path */
 #define MSG_FASTOPEN	0x20000000	/* Send data in TCP SYN */

--- a/include/linux/tcp.h
+++ b/include/linux/tcp.h
@@ -16,6 +16,7 @@
 
 #include <linux/skbuff.h>
 #include <linux/win_minmax.h>
+#include <linux/xarray.h>
 #include <net/sock.h>
 #include <net/inet_connection_sock.h>
 #include <net/inet_timewait_sock.h>
@@ -412,6 +413,11 @@ struct tcp_sock {
 	 */
 	struct request_sock __rcu *fastopen_rsk;
 	struct saved_syn *saved_syn;
+
+/* TCPDirect related information */
+	struct {
+		struct xarray page_pool; /* pool of user-accessible pages */
+	} tcpdirect;
 };
 
 enum tsq_enum {

--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -2609,6 +2609,11 @@ static inline void skb_setup_tx_timestamp(struct sk_buff *skb, __u16 tsflags)
 }
 
 DECLARE_STATIC_KEY_FALSE(tcp_rx_skb_cache_key);
+static inline bool sk_is_tcp(const struct sock *sk)
+{
+	return sk->sk_type == SOCK_STREAM && sk->sk_protocol == IPPROTO_TCP;
+}
+
 /**
  * sk_eat_skb - Release a skb if it is no longer needed
  * @sk: socket to eat this skb from

--- a/include/uapi/linux/dma-buf.h
+++ b/include/uapi/linux/dma-buf.h
@@ -75,6 +75,13 @@ struct dma_buf_sync {
 	__u64 flags;
 };
 
+struct dma_buf_frags_create_info {
+	__u64 pci_bdf[3];
+	__s32 dma_buf_fd;
+	__s32 create_page_pool;
+	__s32 direction;
+};
+
 #define DMA_BUF_SYNC_READ      (1 << 0)
 #define DMA_BUF_SYNC_WRITE     (2 << 0)
 #define DMA_BUF_SYNC_RW        (DMA_BUF_SYNC_READ | DMA_BUF_SYNC_WRITE)
@@ -94,5 +101,7 @@ struct dma_buf_sync {
 #define DMA_BUF_SET_NAME	_IOW(DMA_BUF_BASE, 1, const char *)
 #define DMA_BUF_SET_NAME_A	_IOW(DMA_BUF_BASE, 1, u32)
 #define DMA_BUF_SET_NAME_B	_IOW(DMA_BUF_BASE, 1, u64)
+
+#define DMA_BUF_FRAGS_CREATE   _IOW(DMA_BUF_BASE, 2, struct dma_buf_frags_create_info)
 
 #endif

--- a/include/uapi/linux/dma-buf.h
+++ b/include/uapi/linux/dma-buf.h
@@ -82,6 +82,12 @@ struct dma_buf_frags_create_info {
 	__s32 direction;
 };
 
+struct dma_buf_frags_bind_rx_queue {
+	char *ifname;
+	__u32 ifname_len;
+	__u32 rxq_idx;
+};
+
 #define DMA_BUF_SYNC_READ      (1 << 0)
 #define DMA_BUF_SYNC_WRITE     (2 << 0)
 #define DMA_BUF_SYNC_RW        (DMA_BUF_SYNC_READ | DMA_BUF_SYNC_WRITE)
@@ -103,5 +109,6 @@ struct dma_buf_frags_create_info {
 #define DMA_BUF_SET_NAME_B	_IOW(DMA_BUF_BASE, 1, u64)
 
 #define DMA_BUF_FRAGS_CREATE   _IOW(DMA_BUF_BASE, 2, struct dma_buf_frags_create_info)
+#define DMA_BUF_FRAGS_BIND_RX  _IOW(DMA_BUF_BASE, 3, struct dma_buf_frags_bind_rx_queue)
 
 #endif

--- a/mm/swap.c
+++ b/mm/swap.c
@@ -36,6 +36,7 @@
 #include <linux/hugetlb.h>
 #include <linux/page_idle.h>
 #include <linux/pci-p2pdma.h>
+#include <linux/dma-buf.h>
 #include <linux/local_lock.h>
 #include <linux/buffer_head.h>
 
@@ -122,6 +123,12 @@ void __put_page(struct page *page)
 		set_page_count(page, 1);
 		pci_free_p2pmem_page(page);
 		return;
+	} else if (unlikely(is_dma_buf_frags_dummy_page(page))) {
+		if (page->pgmap->ops && page->pgmap->ops->page_free) {
+			page->pgmap->ops->page_free(page);
+			return;
+		} else
+			BUG();
 	} else if (is_zone_device_page(page)) {
 		put_dev_pagemap(page->pgmap);
 

--- a/mm/swap.c
+++ b/mm/swap.c
@@ -115,6 +115,10 @@ static void __put_compound_page(struct page *page)
 void __put_page(struct page *page)
 {
 	if (unlikely(is_pci_p2pdma_page(page))) {
+		if (page->pgmap->ops && page->pgmap->ops->page_free) {
+			page->pgmap->ops->page_free(page);
+			return;
+		}
 		set_page_count(page, 1);
 		pci_free_p2pmem_page(page);
 		return;

--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -1347,11 +1347,11 @@ int skb_zerocopy_iter_dgram(struct sk_buff *skb, struct msghdr *msg, int len)
 EXPORT_SYMBOL_GPL(skb_zerocopy_iter_dgram);
 
 int skb_zerocopy_iter_stream(struct sock *sk, struct sk_buff *skb,
-			     struct msghdr *msg, int len,
+			     struct iov_iter *iov_iter, int len,
 			     struct ubuf_info *uarg)
 {
 	struct ubuf_info *orig_uarg = skb_zcopy(skb);
-	struct iov_iter orig_iter = msg->msg_iter;
+	struct iov_iter orig_iter = *iov_iter;
 	int err, orig_len = skb->len;
 
 	/* An skb can only point to one uarg. This edge case happens when
@@ -1360,12 +1360,12 @@ int skb_zerocopy_iter_stream(struct sock *sk, struct sk_buff *skb,
 	if (orig_uarg && uarg != orig_uarg)
 		return -EEXIST;
 
-	err = __zerocopy_sg_from_iter(sk, skb, &msg->msg_iter, len);
+	err = __zerocopy_sg_from_iter(sk, skb, iov_iter, len);
 	if (err == -EFAULT || (err == -EMSGSIZE && skb->len == orig_len)) {
 		struct sock *save_sk = skb->sk;
 
 		/* Streams do not free skb on error. Reset to prev state. */
-		msg->msg_iter = orig_iter;
+		*iov_iter = orig_iter;
 		skb->sk = sk;
 		___pskb_trim(skb, orig_len);
 		skb->sk = save_sk;

--- a/net/core/skbuff.c
+++ b/net/core/skbuff.c
@@ -2353,6 +2353,10 @@ int skb_copy_bits(const struct sk_buff *skb, int offset, void *to, int len)
 			skb_frag_foreach_page(f,
 					      skb_frag_off(f) + offset - start,
 					      copy, p, p_off, p_len, copied) {
+				if (is_pci_p2pdma_page(p)) {
+					printk(KERN_ERR "Mapping p2pdma page!");
+					dump_stack();
+				}
 				vaddr = kmap_atomic(p);
 				memcpy(to + copied, vaddr + p_off, p_len);
 				kunmap_atomic(vaddr);
@@ -4363,6 +4367,9 @@ int skb_gro_receive(struct sk_buff *p, struct sk_buff *skb)
 		unsigned int first_size = headlen - offset;
 		unsigned int first_offset;
 
+		if (skb_devmem_frag(lp))
+			goto merge;
+
 		if (nr_frags + 1 + skbinfo->nr_frags > MAX_SKB_FRAGS)
 			goto merge;
 
@@ -5378,12 +5385,15 @@ bool skb_try_coalesce(struct sk_buff *to, struct sk_buff *from,
 	if (to->pp_recycle != from->pp_recycle)
 		return false;
 
-	if (len <= skb_tailroom(to)) {
+	if (len <= skb_tailroom(to) && !skb_devmem_frag(from)) {
 		if (len)
 			BUG_ON(skb_copy_bits(from, 0, skb_put(to, len), len));
 		*delta_truesize = 0;
 		return true;
 	}
+
+	if (skb_devmem_frag(from) || skb_devmem_frag(to))
+	        return false;
 
 	to_shinfo = skb_shinfo(to);
 	from_shinfo = skb_shinfo(from);
@@ -6377,6 +6387,9 @@ void skb_condense(struct sk_buff *skb)
 	if (skb->data_len) {
 		if (skb->data_len > skb->end - skb->tail ||
 		    skb_cloned(skb))
+			return;
+
+		if (skb_devmem_frag(skb))
 			return;
 
 		/* Nice, we can free page frag(s) right now */

--- a/net/core/sock_map.c
+++ b/net/core/sock_map.c
@@ -511,12 +511,6 @@ static bool sock_map_op_okay(const struct bpf_sock_ops_kern *ops)
 	       ops->op == BPF_SOCK_OPS_TCP_LISTEN_CB;
 }
 
-static bool sk_is_tcp(const struct sock *sk)
-{
-	return sk->sk_type == SOCK_STREAM &&
-	       sk->sk_protocol == IPPROTO_TCP;
-}
-
 static bool sock_map_redirect_allowed(const struct sock *sk)
 {
 	if (sk_is_tcp(sk))

--- a/net/ipv4/tcp_input.c
+++ b/net/ipv4/tcp_input.c
@@ -5136,6 +5136,12 @@ tcp_collapse(struct sock *sk, struct sk_buff_head *list, struct rb_root *root,
 	struct sk_buff_head tmp;
 	bool end_of_skbs;
 
+	/* Skipping this function for now as this function potentially
+	 * merges two skbuffs, which could be a issue if one of them contains
+	 * p2pdma pages
+	 */
+	return;
+
 	/* First, check that queue is collapsible and find
 	 * the point where collapsing can be useful.
 	 */

--- a/net/ipv4/tcp_ipv4.c
+++ b/net/ipv4/tcp_ipv4.c
@@ -2252,6 +2252,14 @@ void tcp_v4_destroy_sock(struct sock *sk)
 {
 	struct tcp_sock *tp = tcp_sk(sk);
 
+	unsigned long index;
+	struct page *page;
+	xa_for_each(&(tp->tcpdirect.page_pool), index, page) {
+		put_page(page);
+	}
+
+	xa_destroy(&(tp->tcpdirect.page_pool));
+
 	trace_tcp_destroy_sock(sk);
 
 	tcp_clear_xmit_timers(sk);


### PR DESCRIPTION
patches for the Tx path, and a dma-buf based implementation for the same functionality.